### PR TITLE
Update core.py price class

### DIFF
--- a/fast_flights/core.py
+++ b/fast_flights/core.py
@@ -87,7 +87,7 @@ def parse_response(
             delay = safe(item.css_first(".GsCCve")).text() or None
 
             # Get prices
-            price = safe(item.css_first(".YMlIz.FpEdXe")).text() or "0"
+            price = safe(item.css_first(".YMlIz.FpEdX")).text() or "0"
 
             # Stops formatting
             try:


### PR DESCRIPTION
The classes used for price should be `.YMlIz.FpEdX` but there's a trailing `e` that causes the query to fail.